### PR TITLE
[DM-28050] Make repository URL configurable

### DIFF
--- a/science-platform/templates/argocd-application.yaml
+++ b/science-platform/templates/argocd-application.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     path: services/argocd
-    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    repoURL: {{ .Values.repoURL }}
     targetRevision: {{ .Values.argocd.revision }}
     helm:
       valueFiles:

--- a/science-platform/templates/cachemachine-application.yaml
+++ b/science-platform/templates/cachemachine-application.yaml
@@ -21,7 +21,7 @@ spec:
   project: default
   source:
     path: services/cachemachine
-    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    repoURL: {{ .Values.repoURL }}
     targetRevision: {{ .Values.cachemachine.revision }}
     helm:
       valueFiles:

--- a/science-platform/templates/cert-issuer-application.yaml
+++ b/science-platform/templates/cert-issuer-application.yaml
@@ -13,7 +13,7 @@ spec:
   project: default
   source:
     path: services/cert-issuer
-    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    repoURL: {{ .Values.repoURL }}
     targetRevision: {{ .Values.cert_manager.revision }}
     helm:
       valueFiles:

--- a/science-platform/templates/cert-manager-application.yaml
+++ b/science-platform/templates/cert-manager-application.yaml
@@ -21,7 +21,7 @@ spec:
   project: default
   source:
     path: services/cert-manager
-    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    repoURL: {{ .Values.repoURL }}
     targetRevision: {{ .Values.cert_manager.revision }}
   ignoreDifferences:
     - group: admissionregistration.k8s.io

--- a/science-platform/templates/chronograf-application.yaml
+++ b/science-platform/templates/chronograf-application.yaml
@@ -21,7 +21,7 @@ spec:
   project: default
   source:
     path: services/chronograf
-    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    repoURL: {{ .Values.repoURL }}
     targetRevision: {{ .Values.chronograf.revision }}
     helm:
       valueFiles:

--- a/science-platform/templates/exposurelog-application.yaml
+++ b/science-platform/templates/exposurelog-application.yaml
@@ -18,7 +18,7 @@ spec:
   project: default
   source:
     path: services/exposurelog
-    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    repoURL: {{ .Values.repoURL }}
     targetRevision: {{ .Values.exposurelog.revision }}
     helm:
       valueFiles:

--- a/science-platform/templates/gafaelfawr-application.yaml
+++ b/science-platform/templates/gafaelfawr-application.yaml
@@ -21,7 +21,7 @@ spec:
   project: default
   source:
     path: services/gafaelfawr
-    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    repoURL: {{ .Values.repoURL }}
     targetRevision: {{ .Values.gafaelfawr.revision }}
     helm:
       valueFiles:

--- a/science-platform/templates/influxdb-application.yaml
+++ b/science-platform/templates/influxdb-application.yaml
@@ -21,7 +21,7 @@ spec:
   project: default
   source:
     path: services/influxdb
-    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    repoURL: {{ .Values.repoURL }}
     targetRevision: {{ .Values.influxdb.revision }}
     helm:
       valueFiles:

--- a/science-platform/templates/kapacitor-application.yaml
+++ b/science-platform/templates/kapacitor-application.yaml
@@ -21,7 +21,7 @@ spec:
   project: default
   source:
     path: services/kapacitor
-    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    repoURL: {{ .Values.repoURL }}
     targetRevision: {{ .Values.kapacitor.revision }}
     helm:
       valueFiles:

--- a/science-platform/templates/landing-page-application.yaml
+++ b/science-platform/templates/landing-page-application.yaml
@@ -21,7 +21,7 @@ spec:
   project: default
   source:
     path: services/landing-page
-    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    repoURL: {{ .Values.repoURL }}
     targetRevision: {{ .Values.landing_page.revision }}
     helm:
       valueFiles:

--- a/science-platform/templates/logging-application.yaml
+++ b/science-platform/templates/logging-application.yaml
@@ -21,7 +21,7 @@ spec:
   project: default
   source:
     path: services/logging
-    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    repoURL: {{ .Values.repoURL }}
     targetRevision: {{ .Values.logging.revision }}
     helm:
       valueFiles:

--- a/science-platform/templates/mobu-application.yaml
+++ b/science-platform/templates/mobu-application.yaml
@@ -21,7 +21,7 @@ spec:
   project: default
   source:
     path: services/mobu
-    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    repoURL: {{ .Values.repoURL }}
     targetRevision: {{ .Values.mobu.revision }}
     helm:
       valueFiles:

--- a/science-platform/templates/nginx-ingress-application.yaml
+++ b/science-platform/templates/nginx-ingress-application.yaml
@@ -21,7 +21,7 @@ spec:
   project: default
   source:
     path: services/nginx-ingress
-    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    repoURL: {{ .Values.repoURL }}
     targetRevision: {{ .Values.nginx_ingress.revision }}
     helm:
       valueFiles:

--- a/science-platform/templates/nublado-application.yaml
+++ b/science-platform/templates/nublado-application.yaml
@@ -21,7 +21,7 @@ spec:
   project: default
   source:
     path: services/nublado
-    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    repoURL: {{ .Values.repoURL }}
     targetRevision: {{ .Values.nublado.revision }}
     helm:
       valueFiles:

--- a/science-platform/templates/nublado-users-application.yaml
+++ b/science-platform/templates/nublado-users-application.yaml
@@ -13,6 +13,6 @@ spec:
   project: default
   source:
     path: services/nublado-users
-    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    repoURL: {{ .Values.repoURL }}
     targetRevision: {{ .Values.nublado.revision }}
 {{- end -}}

--- a/science-platform/templates/nublado2-application.yaml
+++ b/science-platform/templates/nublado2-application.yaml
@@ -21,7 +21,7 @@ spec:
   project: default
   source:
     path: services/nublado2
-    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    repoURL: {{ .Values.repoURL }}
     targetRevision: {{ .Values.nublado2.revision }}
     helm:
       valueFiles:

--- a/science-platform/templates/obstap-application.yaml
+++ b/science-platform/templates/obstap-application.yaml
@@ -21,7 +21,7 @@ spec:
   project: default
   source:
     path: services/obstap
-    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    repoURL: {{ .Values.repoURL }}
     targetRevision: {{ .Values.obstap.revision }}
     helm:
       valueFiles:

--- a/science-platform/templates/portal-application.yaml
+++ b/science-platform/templates/portal-application.yaml
@@ -18,7 +18,7 @@ spec:
   project: default
   source:
     path: services/portal
-    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    repoURL: {{ .Values.repoURL }}
     targetRevision: {{ .Values.portal.revision }}
     helm:
       valueFiles:

--- a/science-platform/templates/postgres-application.yaml
+++ b/science-platform/templates/postgres-application.yaml
@@ -18,7 +18,7 @@ spec:
   project: default
   source:
     path: services/postgres
-    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    repoURL: {{ .Values.repoURL }}
     targetRevision: {{ .Values.postgres.revision }}
     helm:
       valueFiles:

--- a/science-platform/templates/squash-api-application.yaml
+++ b/science-platform/templates/squash-api-application.yaml
@@ -21,7 +21,7 @@ spec:
   project: default
   source:
     path: services/squash-api
-    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    repoURL: {{ .Values.repoURL }}
     targetRevision: {{ .Values.squash_api.revision }}
     helm:
       valueFiles:

--- a/science-platform/templates/tap-application.yaml
+++ b/science-platform/templates/tap-application.yaml
@@ -21,7 +21,7 @@ spec:
   project: default
   source:
     path: services/tap
-    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    repoURL: {{ .Values.repoURL }}
     targetRevision: {{ .Values.tap.revision }}
     helm:
       valueFiles:

--- a/science-platform/templates/vault-secrets-operator-application.yaml
+++ b/science-platform/templates/vault-secrets-operator-application.yaml
@@ -13,7 +13,7 @@ spec:
   project: default
   source:
     path: services/vault-secrets-operator
-    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    repoURL: {{ .Values.repoURL }}
     targetRevision: {{ .Values.vault_secrets_operator.revision }}
     helm:
       valueFiles:

--- a/science-platform/templates/wf-application.yaml
+++ b/science-platform/templates/wf-application.yaml
@@ -18,6 +18,6 @@ spec:
   project: default
   source:
     path: services/wf
-    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    repoURL: {{ .Values.repoURL }}
     targetRevision: {{ .Values.argo.revision }}
 {{- end -}}

--- a/science-platform/values.yaml
+++ b/science-platform/values.yaml
@@ -63,3 +63,5 @@ tap:
 vault_secrets_operator:
   enabled: false
   revision: HEAD
+
+repoURL: https://github.com/lsst-sqre/lsp-deploy.git


### PR DESCRIPTION
Okay, so part of the problem with forking this repo is that the
repo URL is checked into a bunch of the templates.  It's all the
same, so first, let's parameterize that out to a values.yaml file
with the default being what it currently was hardcoded to.

But this allows the install.sh script to override that value while
creating the science-platform app, allowing it to point to whatever
the current repository that it is being run from is (and not the
original lsp-deploy).